### PR TITLE
Update meeting day and place for 2024

### DIFF
--- a/frontend/javascript/index.js
+++ b/frontend/javascript/index.js
@@ -6,13 +6,13 @@ import components from "bridgetownComponents/**/*.{js,jsx,js.rb,css}"
 
 console.info("Bridgetown is loaded!")
 
-function getNextThirdTuesday() {
+function getNextNthTuesday(n) {
   const today = new Date();
   let month = today.getMonth();
   let year = today.getFullYear();
 
-  // Check if the current day is after the third Tuesday
-  if (today.getDate() > 15) {
+  // Check if the current day is after the Nth Tuesday
+  if (today.getDate() > (n - 1) * 7 + 1) {
     // Move to the next month
     month++;
     if (month > 11) {
@@ -28,20 +28,20 @@ function getNextThirdTuesday() {
     nextMonth.setDate(nextMonth.getDate() + 1);
   }
 
-  // Add 14 days to get the third Tuesday
-  nextMonth.setDate(nextMonth.getDate() + 14);
+  // Add weeks to get the Nth Tuesday
+  nextMonth.setDate(nextMonth.getDate() + (n - 1) * 7);
 
   return nextMonth;
 }
 
-function updateThirdTuesday() {
-  const nextThirdTuesday = getNextThirdTuesday();
+function updateMeetingDate() {
+  const nextFirstTuesday = getNextNthTuesday(1);
   const options = { weekday: 'long', month: 'long', day: 'numeric' };
-  const formattedDate = nextThirdTuesday.toLocaleDateString('en-US', options);
+  const formattedDate = nextFirstTuesday.toLocaleDateString('en-US', options);
 
   const meetingDate = document.getElementById('meeting-date');
   meetingDate.textContent = formattedDate;
 }
 
-updateThirdTuesday();
+updateMeetingDate();
 

--- a/frontend/styles/index.css
+++ b/frontend/styles/index.css
@@ -77,6 +77,11 @@ main {
   }
 }
 
+#meeting-date {
+  font-weight: bold;
+  color: var(--action-color);
+}
+
 footer {
   text-align: center;
   margin-bottom: 4rem;

--- a/src/index.md
+++ b/src/index.md
@@ -1,9 +1,7 @@
 ---
-# Feel free to add content and custom Front Matter to this file.
-
 layout: default
 ---
 
 # Welcome to Bluegrass Ruby
 
-Bluegrass Ruby was started by [Jos O'shea](https://ruby.social/@whatnotery) in Spring of 2023 in hopes of bringing together Lexington's Ruby Community. We meet at 6:00PM on the third Tuesday of the month at space graciously provided by [Base110](https://www.basehere.com/base110) at 110 West Vine Street in downtown Lexington. Our next meeting will be <span id="meeting-date"></span>. See our Meetups through the navigation link and also follow us on Mastodon for more updates! 
+Bluegrass Ruby was started by [Jos O'shea](https://ruby.social/@whatnotery) in Spring of 2023 in hopes of bringing together Lexington's Ruby Community. We meet at 6:00 PM on the first Tuesday of each month at space graciously provided by [Awesome Inc](https://awesomeinc.org) at 348 East Main Street in downtown Lexington. Our next meeting will be <span id="meeting-date"></span>. See our Meetups through the navigation link, and also follow us on Mastodon for more updates!

--- a/src/index.md
+++ b/src/index.md
@@ -4,4 +4,6 @@ layout: default
 
 # Welcome to Bluegrass Ruby
 
-Bluegrass Ruby was started by [Jos O'shea](https://ruby.social/@whatnotery) in Spring of 2023 in hopes of bringing together Lexington's Ruby Community. We meet at 6:00 PM on the first Tuesday of each month at space graciously provided by [Awesome Inc](https://awesomeinc.org) at 348 East Main Street in downtown Lexington. Our next meeting will be <span id="meeting-date"></span>. See our Meetups through the navigation link, and also follow us on Mastodon for more updates!
+We meet at 6:00 PM on the first Tuesday of each month at [Awesome Inc](https://awesomeinc.org) at 348 East Main Street in downtown Lexington.
+
+Our next meeting will be <span id="meeting-date"></span>. See our Meetups through the navigation link, and also follow us on Mastodon for more updates!


### PR DESCRIPTION
In anticipation of us resuming meetings this year, this PR makes a few updates to the homepage:

- **Meeting day:** from the 3rd to 1st Tuesday.
- **Location:** from Base110 to Awesome Inc.
- **Misc. changes for readability:** shorten the text, emphasize the next meeting date.

Feedback / suggested changes are welcome!

## Before
![BGRB-homepage-before](https://github.com/whatnotery/bluegrass_ruby/assets/9300391/f9a6d8d2-0094-4680-a6b1-b808138af1bd)

## After
![BGRB-homepage-after](https://github.com/whatnotery/bluegrass_ruby/assets/9300391/9c4be5f1-243c-45f4-8cd0-eead6d7d2897)