### PR TITLE
Improve SEO, pt. 2: Expand meta description and homepage content

### DIFF
--- a/src/_data/site_metadata.yml
+++ b/src/_data/site_metadata.yml
@@ -7,4 +7,4 @@
 title: Bluegrass Ruby
 tagline: Lexington, KY Ruby users group
 email: rubyists@bluegrassdevs.org
-description: Lexington, KY Ruby users group
+description: A low-key Ruby meetup in Lexington, Kentucky, for beginners and professionals alike. We meet monthly to hear a talk or explore a Ruby topic together.

--- a/src/index.md
+++ b/src/index.md
@@ -4,6 +4,10 @@ layout: default
 
 # Welcome to Bluegrass Ruby
 
-We meet at 6:00 PM on the first Tuesday of each month at [Awesome Inc](https://awesomeinc.org) at 348 East Main Street in downtown Lexington.
+We meet at 6:00 PM on the first Tuesday of each month at [Awesome Inc](https://awesomeinc.org) at 348 E Main St in downtown Lexington, Kentucky.
 
 Our next meeting will be <a id="meeting-date" href="https://guild.host/bluegrass-ruby/events/upcoming"></a>.
+
+We also chat in the [Bluegrass Developers Guild](https://www.bluegrassdevs.org) Slack in the `#ruby` channel.
+
+Our attendees are of varying experience levels, so you're welcome to join us even if you don't know Ruby yet!


### PR DESCRIPTION
Follow-up to #3 to:

- make an actual meta description
- add content to the home page: link to Bluegrass Dev Guild, and note that any experience level is welcome

I see that I have push access now (thanks @whatnotery!) but I felt this should be a PR since it changes very visible content.

## Screenshots

|         | before | after |
| ------- | ------ | ----- |
| home page |  <img width="644" alt="image" src="https://github.com/user-attachments/assets/6a10d749-6bbf-4ba0-b438-e864380929dc">  |  <img width="646" alt="image" src="https://github.com/user-attachments/assets/2fa81259-3d55-41aa-9b33-dfdb16cf7bb6">  |